### PR TITLE
Add logo and QR code to generated deck images

### DIFF
--- a/src/app/[deckCode]/page.tsx
+++ b/src/app/[deckCode]/page.tsx
@@ -40,6 +40,7 @@ export default function Home(props: { params: Promise<{ deckCode: string }> }) {
               isScene: card.feature_value === "scene",
             })),
             deckUrl: `${window.location.origin}/${deckCode}`,
+            deckCode,
           }),
         });
 
@@ -49,10 +50,11 @@ export default function Home(props: { params: Promise<{ deckCode: string }> }) {
 
         const blob = await response.blob();
         setImageUrl(URL.createObjectURL(blob));
-        setIsGeneratingImage(false);
       } catch (error) {
         console.error(error);
         alert(t("deck.generateImageFailed"));
+      } finally {
+        setIsGeneratingImage(false);
       }
     },
     [t]

--- a/src/app/[deckCode]/page.tsx
+++ b/src/app/[deckCode]/page.tsx
@@ -39,6 +39,7 @@ export default function Home(props: { params: Promise<{ deckCode: string }> }) {
               count: card.count,
               isScene: card.feature_value === "scene",
             })),
+            deckUrl: `${window.location.origin}/${deckCode}`,
           }),
         });
 

--- a/src/pages/api/generate-image.ts
+++ b/src/pages/api/generate-image.ts
@@ -19,7 +19,8 @@ interface GenerateCollageRequest extends NextApiRequest {
 const BG_WIDTH = 1024;
 const BG_HEIGHT = 512;
 const PADDING = 24;
-const LOGO_SIZE = 80;
+const LOGO_WIDTH = 120;
+const LOGO_HEIGHT = 60;
 const QR_SIZE = 120;
 
 function cardsPerColumn(cardCount: number): number {
@@ -117,7 +118,7 @@ export default async function handler(
 
     try {
       const logoBuffer = await sharp(path.join(process.cwd(), "public", "logo.png"))
-        .resize(LOGO_SIZE, LOGO_SIZE)
+        .resize(LOGO_WIDTH, LOGO_HEIGHT)
         .png()
         .toBuffer();
       overlayData.push({ input: logoBuffer, left: PADDING, top: PADDING });

--- a/src/pages/api/generate-image.ts
+++ b/src/pages/api/generate-image.ts
@@ -19,10 +19,10 @@ interface GenerateCollageRequest extends NextApiRequest {
 const BG_WIDTH = 1024;
 const BG_HEIGHT = 512;
 const PADDING = 24;
-const LOGO_PADDING = 8;
+const LOGO_PADDING = 4;
 const LOGO_WIDTH = 120;
 const LOGO_HEIGHT = 60;
-const QR_SIZE = 40;
+const QR_SIZE = 60;
 
 function cardsPerColumn(cardCount: number): number {
   if (cardCount <= 4)
@@ -78,7 +78,7 @@ export default async function handler(
 
   try {
     const overlayHeight = deckUrl ? Math.max(LOGO_HEIGHT, QR_SIZE) : LOGO_HEIGHT;
-    const reservedTop = overlayHeight + LOGO_PADDING * 2;
+    const reservedTop = overlayHeight + LOGO_PADDING;
     const columns = Math.ceil(images.length / cardsPerColumn(images.length));
     const rows = Math.ceil(images.length / columns);
     const CARD_WIDTH = 2 * Math.floor(cardSize(columns, rows, reservedTop).width / 2);


### PR DESCRIPTION
### Motivation

- Add branding and a quick-share link to generated deck images by compositing the site logo in the top-left and a QR code for the deck URL in the top-right of the collage.

### Description

- Include `deckUrl` in the image-generation payload sent from `src/app/[deckCode]/page.tsx` via the `generateCollage` request body.
- Extend `src/pages/api/generate-image.ts` to accept `deckUrl` and introduce `LOGO_SIZE` and `QR_SIZE` constants for overlay sizing.
- Load `public/logo.png`, resize it, and composite it at `left: PADDING, top: PADDING` and, when `deckUrl` is provided, request a QR image from `https://api.qrserver.com`, resize it, and composite it at the top-right corner; both overlays are merged into the final image along with the card tiles.
- Add graceful error handling for logo/QR fetch failures so collage generation still succeeds if overlays cannot be created.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e038d551c8321aad45ac762fc228b)